### PR TITLE
Add X11-config to disable inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Copy sennheiser-gsx-1000.conf to `/usr/share/pulseaudio/alsa-mixer/profile-sets/
 
 Copy 91-pulseaudio-gsx1000.rules to `/lib/udev/rules.d/`
 
+Copy 40-sennheiser-gsx-1000.conf to `/etc/X11/xorg.conf.d/40-sennheiser-gsx-1000.conf` to disable it as an input device. The reason you would want to do this is because the big wheel always maps to volume down, so turning it will always lower your volume to zero. This is a temporary fix which just disables it as an input device so that turning the wheel will not modify the internal volume specifier, without affecting your normal media keys.
+
 (Or wherever your correspondig folders are located. This should be good for Debian/Mint/Ubuntu.
 
 Reload and trigger udev (as root)

--- a/etc/X11/xorg.conf.d/40-sennheiser-gsx-1000.conf
+++ b/etc/X11/xorg.conf.d/40-sennheiser-gsx-1000.conf
@@ -1,0 +1,5 @@
+Section "InputClass"
+    Identifier "disable Sennheiser GSX 1000 as an input device"
+    MatchProduct "Sennheiser GSX 1000 Main Audio"
+    Option "Ignore" "on"
+EndSection


### PR DESCRIPTION
This adds a small X11 config file which can be added to disable the device as an input device. That way turning the wheel will not lower the volume to zero, and one does not have to disable the normal media keys.