### PR TITLE
Added udev hwdb, corrected debian install

### DIFF
--- a/etc/udev/hwdb.d/sennheiser-gsx.hwdb
+++ b/etc/udev/hwdb.d/sennheiser-gsx.hwdb
@@ -1,0 +1,2 @@
+evdev:input:b0003v1395p005E*
+  KEYBOARD_KEY_C00EA=reserved

--- a/install.sh
+++ b/install.sh
@@ -41,6 +41,13 @@ then
   echo "Skipped pulseaudio restart"
 else
   echo "Restarting pulse audio"
-  systemctl --user restart pulseaudio.service
+  # ignore errors if we restart too often / to fast .. we just ensure to nuke it
+  pulseaudio -k > /dev/null 2>&1 || true
+  pulseaudio -k > /dev/null 2>&1 || true
+  pulseaudio -k > /dev/null 2>&1 || true
+
+  echo "Ensure pulseaudio is started"
+  sleep 2
+  pulseaudio -D
 fi
 


### PR DESCRIPTION
Added the hwdb to make sure that the volume dial is ignored, even outside of X.
Using the correct method to restart pulseaudio.

Also to note debian vendor config is in /usr/share, user config should still be in /etc
https://wiki.debian.org/Xorg#What_if_I_do_not_have_a_xorg_config_file.3F
so ive created a check to create the appropriate directories if needed then installs the xorg config.