### PR TITLE
Some distros have udev on /etc instead of /lib

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -12,7 +12,16 @@ fi
   sudo cp usr/share/X11/xorg.conf.d/40-sennheiser-gsx-$type.conf /etc/X11/xorg.conf.d/
 
 echo "Installing udev rule"
-sudo cp lib/udev/rules.d/91-pulseaudio-gsx$type.rules /lib/udev/rules.d/
+if [ -d /lib/udev/rules.d/ ]; then
+  echo "Udev located in /lib"
+  sudo cp lib/udev/rules.d/91-pulseaudio-gsx$type.rules /lib/udev/rules.d/
+elif [ -d /etc/udev/rules.d/ ]; then
+  echo "Udev located in /etc"
+  sudo cp lib/udev/rules.d/91-pulseaudio-gsx$type.rules /etc/udev/rules.d/
+else
+  echo "Udev rules route not found, hence cancelling installation"
+  echo "Expected locations: /etc/udev/rules.d/ OR /lib/udev/rules.d/"
+fi
 
 echo "Installing udev hwdb"
 sudo cp etc/udev/hwdb.d/sennheiser-gsx.hwdb /etc/udev/hwdb.d/

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -8,6 +8,7 @@ echo "Uninstalling GSX-$type"
 sudo rm -f /usr/share/X11/xorg.conf.d/40-sensheiser-gsx-$type.conf
 sudo rm -f /etc/X11/xorg.conf.d/40-sensheiser-gsx-$type.conf
 sudo rm -f /lib/udev/rules.d/91-pulseaudio-gsx$type.rules 
+sudo rm -f /etc/udev/rules.d/91-pulseaudio-gsx$type.rules 
 sudo rm -f /usr/share/pulseaudio/alsa-mixer/profile-sets/sennheiser-gsx-$type.conf
 
 echo "Reloading udev rules"


### PR DESCRIPTION
Solus and probably some other distros don't have udev rules under /lib/udev/rules.d/ but instead under /etc/udev/rules.d/.

This add the logic for the installer to detect "if /lib exist, or if /etc exist, if none exists cancel the installation". I have added to the Uninstall script the rm for the /etc/ path as well.