### PR TITLE
Fix broken link to config file in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -39,7 +39,7 @@ else
 fi
 
 if [ -d /usr/share/alsa-card-profile/mixer/profile-sets ]; then
-  sudo ln -s /usr/share/pulseaudio/alsa-mixer/profile-sets/sennheiser-gsx.conf /usr/share/alsa-card-profile/mixer/profile-sets/
+  sudo ln -s /usr/share/pulseaudio/alsa-mixer/profile-sets/sennheiser-gsx-$type.conf /usr/share/alsa-card-profile/mixer/profile-sets/
 fi
 
 echo "Reloading udev rules"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -10,7 +10,7 @@ sudo rm -f /etc/X11/xorg.conf.d/40-sensheiser-gsx-$type.conf
 sudo rm -f /lib/udev/rules.d/91-pulseaudio-gsx$type.rules 
 sudo rm -f /etc/udev/rules.d/91-pulseaudio-gsx$type.rules 
 sudo rm -f /usr/share/pulseaudio/alsa-mixer/profile-sets/sennheiser-gsx-$type.conf
-sudo rm -f /usr/share/alsa-card-profile/mixer/profile-sets/sennheiser-gsx.conf
+sudo rm -f /usr/share/alsa-card-profile/mixer/profile-sets/sennheiser-gsx-$type.conf
 
 echo "Reloading udev rules"
 sudo udevadm control -R


### PR DESCRIPTION
The links points to a file that is named differently by the installer