### PR TITLE
Change ordering of output-mapping

### DIFF
--- a/usr/share/pulseaudio/alsa-mixer/profile-sets/sennheiser-gsx-1000.conf
+++ b/usr/share/pulseaudio/alsa-mixer/profile-sets/sennheiser-gsx-1000.conf
@@ -61,7 +61,7 @@ priority = 2
 # Combined output profile
 [Profile output:analog-output-surround71+output:analog-output-chat+input:analog-input]
 description = 7.1 Surround
-output-mappings = analog-output-surround71 analog-output-chat
+output-mappings = analog-output-chat analog-output-surround71
 input-mappings = analog-input
 priority = 88
 skip-probe = yes

--- a/usr/share/pulseaudio/alsa-mixer/profile-sets/sennheiser-gsx-1200.conf
+++ b/usr/share/pulseaudio/alsa-mixer/profile-sets/sennheiser-gsx-1200.conf
@@ -61,7 +61,7 @@ priority = 2
 # Combined output profile
 [Profile output:analog-output-surround71+output:analog-output-chat+input:analog-input]
 description = 7.1 Surround
-output-mappings = analog-output-surround71 analog-output-chat
+output-mappings = analog-output-chat analog-output-surround71
 input-mappings = analog-input
 priority = 88
 skip-probe = yes


### PR DESCRIPTION
Change ordering to get the MAIN device the default output

Based on https://github.com/raptor2101/sennheiser-gsx-1000/commit/653d2799ad9d12f873f218cfc925c96f6ffce162

Addresses https://gitlab.freedesktop.org/pulseaudio/pulseaudio/-/issues/876