### PR TITLE
Add support for newer GSX devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # sennheiser-gsx-1000 / 1200 Pro
 Getting the Sennheiser GSX 1000 / 1200 Pro DAC to work under Linux
 
+*Note:* [Pulse Audio 15](https://github.com/pulseaudio/pulseaudio/blob/v15.0/NEWS#L17) added native support for the GSX-1XXX series.
+
 ![pavucontrol one](https://raw.githubusercontent.com/evilphish/sennheiser-gsx-1000/master/images/pavucontrol.png)
 ![pavucontrol two](https://raw.githubusercontent.com/evilphish/sennheiser-gsx-1000/master/images/pavucontrol2.png)
 
@@ -89,7 +91,7 @@ done.
 You will get two output devices, **main output** and **chat output**. The **main output** is the 7.1 audio output you want to use for anything with high quality. The **chat output** is a mono output that the GSX1000 / GSX1200 Pro will overlay over your 7.1 audio. You can adjust the offset volume of **chat output** vs **main output** with the small volume rocker knob on the right side of the device. This is especially handy when it comes to mumble or teamspeak. If you pipe those applications into the mono output you can freely adjust the voice overlay with the small knob and still control overall volume with the large knob. It's super effective!
 
 ## What does not work?
-Controlling the software volume with the big wheel results in the volume being lowered to zero as each turning direction counts as the multimedia key Volume-Down. The xorg.conf.d files mentioned above disable key inputs for the GSX devices to work around this issue. You could also delete or disable the multimedia volume keys in your keyboard settings (Who wants to use multimedia keys if you have the GSX 1000 for that). Nonetheless, it would be great if we could teach Linux that turning the knob clockwise means Volume-Up instead of down. If anyone has any insight into this, please drop me a line or open an issue! The internal volume adjustment of the GSX works though! So you can change the volume, just not in your system but in your deveice. 
+Controlling the software volume with the big wheel results in the volume being lowered to zero as each turning direction counts as the multimedia key Volume-Down. The xorg.conf.d files mentioned above disable key inputs for the GSX devices to work around this issue. You could also delete or disable the multimedia volume keys in your keyboard settings (Who wants to use multimedia keys if you have the GSX 1000 for that). Nonetheless, it would be great if we could teach Linux that turning the knob clockwise means Volume-Up instead of down. If anyone has any insight into this, please drop me a line or open an issue! The internal volume adjustment of the GSX works though! So you can change the volume, just not in your system but in your device. 
 
 ## Arch Linux users
 Just reboot after install

--- a/lib/udev/rules.d/91-pulseaudio-gsx1000.rules
+++ b/lib/udev/rules.d/91-pulseaudio-gsx1000.rules
@@ -2,7 +2,7 @@ SUBSYSTEM!="sound", GOTO="pulseaudio_end"
 ACTION!="change", GOTO="pulseaudio_end"
 KERNEL!="card*", GOTO="pulseaudio_end"
 
-ATTRS{idVendor}=="1395", ATTRS{idProduct}=="005e", ENV{PULSE_PROFILE_SET}="sennheiser-gsx-1000.conf", ATTR{id}="GSX1000"
+ATTRS{idVendor}=="1395", ATTRS{idProduct}=="005e|00a0", ENV{PULSE_PROFILE_SET}="sennheiser-gsx-1000.conf", ATTR{id}="GSX1000"
 
 
 LABEL="pulseaudio_end"

--- a/lib/udev/rules.d/91-pulseaudio-gsx1200.rules
+++ b/lib/udev/rules.d/91-pulseaudio-gsx1200.rules
@@ -2,7 +2,7 @@ SUBSYSTEM!="sound", GOTO="pulseaudio_end"
 ACTION!="change", GOTO="pulseaudio_end"
 KERNEL!="card*", GOTO="pulseaudio_end"
 
-ATTRS{idVendor}=="1395", ATTRS{idProduct}=="005f", ENV{PULSE_PROFILE_SET}="sennheiser-gsx-1200.conf", ATTR{id}="GSX1200"
+ATTRS{idVendor}=="1395", ATTRS{idProduct}=="00a1|005f", ENV{PULSE_PROFILE_SET}="sennheiser-gsx-1200.conf", ATTR{id}="GSX1200"
 
 
 LABEL="pulseaudio_end"


### PR DESCRIPTION
I recently bought a GSX 1200, and when I needed to make it work on linux this project was one of the first I found. Thanks for sharing it with us all!

I noticed that the current project wasn't working for my DAC for some reason. One of the open issues mentions that the usb product IDs for the GSX series have changed. https://github.com/evilphish/sennheiser-gsx-1000/issues/26#issuecomment-756174464

To support the old and new product Ids I used the udev regex support to add both.

For people who can use newer versions of pulse audio,
upstream merged a patch which adds support for the 1XXX series. I added it to the readme for visibility.

https://github.com/evilphish/sennheiser-gsx-1000/issues/27